### PR TITLE
Switch local db

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -32,4 +32,4 @@ config :evercam_media, EvercamMedia.Repo,
   extensions: [{EvercamMedia.Types.JSON.Extension, library: Poison}],
   username: "postgres",
   password: "postgres",
-  database: "evercam_dev"
+  database: System.get_env["db"] || "evercam_dev"


### PR DESCRIPTION
Make it easy to switch to different databases locally.

This should now use `evercam_live` db instead of `evercam_dev`
```
db=evercam_live mix phoenix.server
```
to use evercam_dev, use the command without any `db` prefix:
```
mix phoenix.server
```

This PR goes together with another PR on evercam-api: https://github.com/evercam/evercam-api/pull/390


