### PR TITLE
ONVIF PTZ Routes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,4 @@ config :evercam_media, EvercamMedia.Repo,
   extensions: [{EvercamMedia.Types.JSON.Extension, library: Poison}],
   username: "postgres",
   password: "postgres",
-  database: "evercam_tst",
-  size: 1,
-  max_overflow: false
+  database: System.get_env["db"] || "evercam_dev"

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -33,7 +33,7 @@ defmodule EvercamMedia.ONVIFClient do
     end
 
     {wsse_username, wsse_password, wsse_nonce, wsse_created} = get_wsse_header_data(username,password)
-
+   
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
      <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\"
           xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -84,7 +84,7 @@ defmodule EvercamMedia.ONVIFClient do
     [response] = Enum.map(event_elements, fn(event_element) -> 
                                             parse(xmlElement(event_element, :content))
                                            end)
-    Poison.Encoder.encode(response,nil) 
+    response 
   end
 
   defp parse(node) do

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -84,7 +84,7 @@ defmodule EvercamMedia.ONVIFClient do
     [response] = Enum.map(event_elements, fn(event_element) -> 
                                             parse(xmlElement(event_element, :content))
                                            end)
-    Poison.Encoder.encode(response,nil) |> IO.iodata_to_binary
+    Poison.Encoder.encode(response,nil) 
   end
 
   defp parse(node) do

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -1,0 +1,138 @@
+defmodule EvercamMedia.ONVIFClient do
+
+  require Record
+  Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+  Record.defrecord :xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
+  Record.defrecord :xmlAttribute, Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
+  
+ 
+  def onvif_call(host, port, service, method, xpath, username, password, parameters \\ "") do
+    
+     url = "http://#{host}:#{port}/onvif/" <> case service do
+                    :ptz -> "PTZ"
+							      :device ->"device_service"
+							      :media -> "Media" 
+																														end
+		 
+     response =  HTTPotion.post url, [body: gen_onvif_request(service, method, username, password, parameters), headers: ["Content-Type": "application/soap+xml", "SOAPAction": "http://www.w3.org/2003/05/soap-envelope"]] 
+
+     if HTTPotion.Response.success?(response) do
+       {xml, _rest} = :xmerl_scan.string(to_char_list(response.body))
+       {:ok, :xmerl_xpath.string(to_char_list(xpath), xml) |> parse_elements}
+     else
+       {:error, response.status_code, response}
+     end
+  end 
+
+
+  defp gen_onvif_request(service, method, username, password, parameters) do
+    wsdl_url =  case service do
+      :ptz -> "http://www.onvif.org/ver10/ptz/wsdl"
+      :device -> "http://www.onvif.org/ver20/device/wsdl"
+      :media -> "http://www.onvif.org/ver10/media/wsdl"
+    end
+
+    {wsse_username, wsse_password, wsse_nonce, wsse_created} = get_wsse_header_data(username,password)
+
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+     <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\"
+          xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"
+          xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis=200401-wss-wssecurity-utility-1.0.xsd\"> 
+          <SOAP-ENV:Header><wsse:Security><wsse:UsernameToken>
+          <wsse:Username>#{wsse_username}</wsse:Username> 
+          <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest\">#{wsse_password}</wsse:Password>
+          <wsse:Nonce>#{wsse_nonce}</wsse:Nonce>
+          <wsu:Created>#{wsse_created}</wsu:Created></wsse:UsernameToken>
+          </wsse:Security></SOAP-ENV:Header><SOAP-ENV:Body> 
+	        <tds:#{method} xmlns:tds=\"#{wsdl_url}\">#{parameters}</tds:#{method}>
+     </SOAP-ENV:Body></SOAP-ENV:Envelope>"
+  end
+	
+  #### WSSE
+
+  def get_wsse_header_data(user, password) do
+
+    {a, b, c} = :os.timestamp
+    :random.seed(a, b, c)
+    nonce  = nonce(20, []) |> to_string 
+ 
+    created = format_date_time(:erlang.localtime)
+  
+    digest = :crypto.hash(:sha, nonce <> created <> password) |> to_string
+ 
+    {user, Base.encode64(digest), Base.encode64(nonce), created}
+
+  end
+
+  defp format_date_time({{year, month, day}, {hour, minute, second}}) do
+    :io_lib.format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0BZ", [year, month, day, hour, minute, second]) 
+      |> List.flatten
+      |> to_string
+  end
+	
+  defp nonce(0,l) do 
+    l ++ [:random.uniform(255)]
+  end
+
+  defp nonce(n,l) do
+    nonce(n - 1, l ++ [:random.uniform(255)])
+  end 
+
+  #### XML Parsing
+
+  def parse_elements(event_elements) do 
+    [response] = Enum.map(event_elements, fn(event_element) -> 
+                                            parse(xmlElement(event_element, :content))
+                                           end)
+    Poison.Encoder.encode(response,nil) |> IO.iodata_to_binary
+  end
+
+  defp parse(node) do
+
+    cond do
+      Record.is_record(node, :xmlElement) ->
+        [_ns,name] = xmlElement(node, :name) 
+        |> to_string 
+        |> String.split ":"
+        content = xmlElement(node, :content)
+        case xmlElement(node, :attributes) do
+          [] -> Map.put(%{}, name, parse(content))
+          attributes -> Map.put(%{}, name, parse(content) |> Map.merge(parse(attributes)))
+        end
+			  
+      Record.is_record(node, :xmlAttribute) ->
+        name = xmlAttribute(node, :name) |> to_string
+        value = xmlAttribute(node, :value) |> to_string
+        Map.put(%{}, name, value)
+				
+      Record.is_record(node, :xmlText) ->
+        case xmlText(node, :value) |> to_string do
+          "\n" -> %{}
+          value -> Map.put(%{}, "#text", value)	
+	    end
+					 
+      is_list(node) ->
+        case Enum.map(node, &(parse(&1))) do
+          [text_content] when is_map(text_content) ->
+             Map.get(text_content, "#text", text_content)
+
+          elements ->
+              Enum.reduce(elements, %{}, fn(x, acc) ->
+                                            if is_map(x) do
+                                              Map.merge(acc, x, fn(_key, v1, v2) ->
+                                                                   case v1 do
+                                                                     nil -> v2
+                                                                     v when is_list(v) -> v ++ [v2]
+                                                                     _ -> [v1, v2]
+                                                                   end
+                                                                 end)
+                                            else
+                                               acc
+                                            end
+                                          end)
+           end
+         true -> "Not supported to parse #{inspect node}"
+    end
+  end
+end
+

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -84,7 +84,11 @@ defmodule EvercamMedia.ONVIFClient do
     [response] = Enum.map(event_elements, fn(event_element) -> 
                                             parse(xmlElement(event_element, :content))
                                            end)
-    response 
+    if Map.size(response) == 0 do
+      :ok
+    else
+      response
+    end
   end
 
   defp parse(node) do

--- a/lib/onvif/onvif_client.ex
+++ b/lib/onvif/onvif_client.ex
@@ -6,9 +6,9 @@ defmodule EvercamMedia.ONVIFClient do
   Record.defrecord :xmlAttribute, Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
   
  
-  def onvif_call(host, port, service, method, xpath, username, password, parameters \\ "") do
+  def onvif_call(base_url, service, method, xpath, username, password, parameters \\ "") do
     
-     url = "http://#{host}:#{port}/onvif/" <> case service do
+     url = "#{base_url}/onvif/" <> case service do
                     :ptz -> "PTZ"
 							      :device ->"device_service"
 							      :media -> "Media" 

--- a/lib/onvif/onvif_device_management.ex
+++ b/lib/onvif/onvif_device_management.ex
@@ -1,25 +1,25 @@
 defmodule EvercamMedia.ONVIFDeviceManagement do
   alias EvercamMedia.ONVIFClient
 
-  def get_system_date_and_time(host, port, username, password) do
-    device_management_request(host, port,"GetSystemDateAndTime", 
+  def get_system_date_and_time(url, username, password) do
+    device_management_request(url, "GetSystemDateAndTime", 
                               "/env:Envelope/env:Body/tds:GetSystemDateAndTimeResponse/tds:SystemDateAndTime/tt:LocalDateTime", 
                               username, password)
   end
 
-  def get_device_information(host, port, username, password) do
-    device_management_request(host, port,"GetDeviceInformation", 
+  def get_device_information(url, username, password) do
+    device_management_request(url, "GetDeviceInformation", 
                               "/env:Envelope/env:Body/tds:GetDeviceInformationResponse", 
                               username, password)
   end
 
-  def get_network_interfaces(host, port, username, password) do
-    device_management_request(host, port,"GetNetworkInterfaces",
+  def get_network_interfaces(url, username, password) do
+    device_management_request(url, "GetNetworkInterfaces",
                               "/env:Envelope/env:Body/tds:GetNetworkInterfacesResponse/tds:NetworkInterfaces", 
                               username, password)
   end
 
-  def device_management_request(host, port, method, xpath,  username, password) do
-    ONVIFClient.onvif_call(host, port, :device, method, xpath, username, password)
+  def device_management_request(url, method, xpath,  username, password) do
+    ONVIFClient.onvif_call(url, :device, method, xpath, username, password)
   end
 end

--- a/lib/onvif/onvif_device_management.ex
+++ b/lib/onvif/onvif_device_management.ex
@@ -1,0 +1,25 @@
+defmodule EvercamMedia.ONVIFDeviceManagement do
+  alias EvercamMedia.ONVIFClient
+
+  def get_system_date_and_time(host, port, username, password) do
+    device_management_request(host, port,"GetSystemDateAndTime", 
+                              "/env:Envelope/env:Body/tds:GetSystemDateAndTimeResponse/tds:SystemDateAndTime/tt:LocalDateTime", 
+                              username, password)
+  end
+
+  def get_device_information(host, port, username, password) do
+    device_management_request(host, port,"GetDeviceInformation", 
+                              "/env:Envelope/env:Body/tds:GetDeviceInformationResponse", 
+                              username, password)
+  end
+
+  def get_network_interfaces(host, port, username, password) do
+    device_management_request(host, port,"GetNetworkInterfaces",
+                              "/env:Envelope/env:Body/tds:GetNetworkInterfacesResponse/tds:NetworkInterfaces", 
+                              username, password)
+  end
+
+  def device_management_request(host, port, method, xpath,  username, password) do
+    ONVIFClient.onvif_call(host, port, :device, method, xpath, username, password)
+  end
+end

--- a/lib/onvif/onvif_media.ex
+++ b/lib/onvif/onvif_media.ex
@@ -1,13 +1,13 @@
 defmodule EvercamMedia.ONVIFMedia do
   alias EvercamMedia.ONVIFClient
 
-  def get_profiles(host, port, username, password) do
-    media_request(host, port,"GetProfiles",
+  def get_profiles(url, username, password) do
+    media_request(url,"GetProfiles",
                   "/env:Envelope/env:Body/trt:GetProfilesResponse", username, password)
   end
 
- defp media_request(host, port, method, xpath, username, password) do
-   ONVIFClient.onvif_call(host, port, :media, method, xpath, username, password) 
+ defp media_request(url, method, xpath, username, password) do
+   ONVIFClient.onvif_call(url, :media, method, xpath, username, password) 
  end
 end
 

--- a/lib/onvif/onvif_media.ex
+++ b/lib/onvif/onvif_media.ex
@@ -1,0 +1,17 @@
+defmodule EvercamMedia.ONVIFMedia do
+  alias EvercamMedia.ONVIFClient
+
+  def get_profiles(host, port, username, password) do
+    media_request(host, port,"GetProfiles",
+                  "/env:Envelope/env:Body/trt:GetProfilesResponse", username, password)
+  end
+
+ defp media_request(host, port, method, xpath, username, password) do
+   ONVIFClient.onvif_call(host, port, :media, method, xpath, username, password) 
+ end
+end
+
+
+
+
+

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -64,7 +64,7 @@ defmodule EvercamMedia.ONVIFPTZ do
                 "<ProfileToken>#{profile_token}</ProfileToken>"
 	        <> case pan_tilt_zoom_vector velocity do
                      "" -> ""
-	             vector -> "<Velocity>#{vector}</Velocity>"
+	                  vector -> "<Velocity>#{vector}</Velocity>"
                end)
   end
 
@@ -75,7 +75,7 @@ defmodule EvercamMedia.ONVIFPTZ do
                 "<ProfileToken>#{profile_token}</ProfileToken>"
                 <> case pan_tilt_zoom_vector speed do
                      "" -> ""
-	             vector -> "<Speed>#{vector}</Speed>"
+	                   vector  -> "<Speed>#{vector}</Speed>"
                 end)
 
   end
@@ -87,14 +87,19 @@ defmodule EvercamMedia.ONVIFPTZ do
                 <PresetToken>#{preset_token}</PresetToken>")
   end
 
-  def set_preset(url, username, password, profile_token, preset_token, preset_name) do
+  def set_preset(url, username, password, profile_token, preset_name \\ "", preset_token \\ "") do
     ptz_request(url, "SetPreset", 
                 "/env:Envelope/env:Body/tptz:SetPresetResponse", username, password,
-                "<ProfileToken>#{profile_token}</ProfileToken>
-                <PresetName>#{preset_name}</PresetName>
-                <PresetToken>#{preset_token}</PresetToken>")
+                "<ProfileToken>#{profile_token}</ProfileToken>"
+                <> case preset_name do
+                     "" -> ""
+                     _ -> "<PresetName>#{preset_name}</PresetName>"
+                   end
+                <> case preset_token do
+                     "" -> ""
+                     _ -> "<PresetToken>#{preset_token}</PresetToken>"
+                    end)
   end
-
 
   def set_home_position(url, username, password, profile_token) do
     ptz_request(url ,"SetHomePosition", 

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -1,0 +1,85 @@
+defmodule EvercamMedia.ONVIFPTZ do
+
+  alias EvercamMedia.ONVIFClient
+
+  def get_nodes(host, port, username, password) do
+    ptz_request(host, port,"GetNodes", 
+                "/env:Envelope/env:Body/tptz:GetNodesResponse", username, password)
+   end
+
+  def get_configurations(host, port, username, password) do
+    ptz_request(host, port,"GetConfigurations", 
+                "/env:Envelope/env:Body/tptz:GetConfigurationsResponse", username, password)
+  end
+
+  def get_presets(host, port, username, password, profile_token) do
+    {:ok, response} = ptz_request(host, port,"GetPresets", 
+                                  "/env:Envelope/env:Body/tptz:GetPresetsResponse", 
+                                  username, password,
+                                  "<ProfileToken>#{profile_token}</ProfileToken>")
+    {:ok, Map.put(%{}, 
+                  "Presets",
+                  response
+		  |>  Poison.Parser.parse!
+                  |>  Map.get("Preset")
+                  |>  Enum.filter(&(Map.get(&1, "Name") != nil))
+          )
+          |> Poison.Encoder.encode(nil)
+          |> IO.iodata_to_binary}
+  end
+
+  def get_status(host, port, username, password, profile_token) do
+    ptz_request(host, port,"GetStatus", 
+               "/env:Envelope/env:Body/tptz:GetStatusResponse",
+               username, password,
+               "<ProfileToken>#{profile_token}</ProfileToken>")
+  end
+
+
+  def goto_preset(host, port, username, password, profile_token, preset_token, speed \\ []) do
+    ptz_request(host, port,"GotoPreset", "/env:Envelope/env:Body/tptz:GotoPresetResponse", 
+                username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>
+                 <PresetToken>#{preset_token}</PresetToken>"
+		 <> case pan_tilt_zoom_vector speed do
+                      "" -> ""
+		      vector -> "<Speed>#{vector}</Speed>"
+                    end)
+  end
+ 
+  def relative_move(host, port, username, password, profile_token, translation, speed \\ []) do
+    ptz_request(host, port, "RelativeMove", 
+                "/env:Envelope/env:Body/tptz:GotoPresetResponse",username, password,
+                                  "<ProfileToken>#{profile_token}</ProfileToken>
+                                  <Translation>#{pan_tilt_zoom_vector translation}</Translation>"
+		                              <> case pan_tilt_zoom_vector speed do
+                                                   "" -> ""
+		                                   vector -> "<Speed>#{vector}</Speed>"
+	                                         end)
+  end
+ 
+  def stop(host, port, username, password, profile_token) do
+    ptz_request(host, port,"Stop", 
+                "/env:Envelope/env:Body/tptz:StopResponse", 
+                username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>")
+  end
+
+
+  def pan_tilt_zoom_vector(vector) do
+    pan_tilt = case {vector[:x], vector[:y]}  do
+                {nil,_} -> ""
+                {_, nil} -> ""
+                {x,y}  -> "<PanTilt x=\"#{x}\" y=\"#{y}\" xmlns=\"http://www.onvif.org/ver10/schema\"/>"
+	      end
+    zoom = case vector[:zoom] do
+             nil -> ""									 
+             zoom  -> "<Zoom x=\"#{zoom}\"  xmlns=\"http://www.onvif.org/ver10/schema\"/>"
+           end
+    pan_tilt <> zoom
+  end
+
+  defp ptz_request(host, port, method, xpath, username, password, parameters \\ "") do
+    ONVIFClient.onvif_call(host, port, :ptz, method, xpath, username, password, parameters) 
+  end
+end

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -2,18 +2,18 @@ defmodule EvercamMedia.ONVIFPTZ do
 
   alias EvercamMedia.ONVIFClient
 
-  def get_nodes(host, port, username, password) do
-    ptz_request(host, port,"GetNodes", 
+  def get_nodes(url, username, password) do
+    ptz_request(url, "GetNodes", 
                 "/env:Envelope/env:Body/tptz:GetNodesResponse", username, password)
    end
 
-  def get_configurations(host, port, username, password) do
-    ptz_request(host, port,"GetConfigurations", 
+  def get_configurations(url, username, password) do
+    ptz_request(url, "GetConfigurations", 
                 "/env:Envelope/env:Body/tptz:GetConfigurationsResponse", username, password)
   end
 
-  def get_presets(host, port, username, password, profile_token) do
-    {:ok, response} = ptz_request(host, port,"GetPresets", 
+  def get_presets(url, username, password, profile_token \\ "Profile_1") do
+    {:ok, response} = ptz_request(url, "GetPresets", 
                                   "/env:Envelope/env:Body/tptz:GetPresetsResponse", 
                                   username, password,
                                   "<ProfileToken>#{profile_token}</ProfileToken>")
@@ -28,16 +28,16 @@ defmodule EvercamMedia.ONVIFPTZ do
           |> IO.iodata_to_binary}
   end
 
-  def get_status(host, port, username, password, profile_token) do
-    ptz_request(host, port,"GetStatus", 
+  def get_status(url, username, password, profile_token) do
+    ptz_request(url, "GetStatus", 
                "/env:Envelope/env:Body/tptz:GetStatusResponse",
                username, password,
                "<ProfileToken>#{profile_token}</ProfileToken>")
   end
 
 
-  def goto_preset(host, port, username, password, profile_token, preset_token, speed \\ []) do
-    ptz_request(host, port,"GotoPreset", "/env:Envelope/env:Body/tptz:GotoPresetResponse", 
+  def goto_preset(url, username, password, profile_token, preset_token, speed \\ []) do
+    ptz_request(url, "GotoPreset", "/env:Envelope/env:Body/tptz:GotoPresetResponse", 
                 username, password,
                 "<ProfileToken>#{profile_token}</ProfileToken>
                  <PresetToken>#{preset_token}</PresetToken>"
@@ -47,8 +47,8 @@ defmodule EvercamMedia.ONVIFPTZ do
                     end)
   end
  
-  def relative_move(host, port, username, password, profile_token, translation, speed \\ []) do
-    ptz_request(host, port, "RelativeMove", 
+  def relative_move(url, username, password, profile_token, translation, speed \\ []) do
+    ptz_request(url, "RelativeMove", 
                 "/env:Envelope/env:Body/tptz:GotoPresetResponse",username, password,
                                   "<ProfileToken>#{profile_token}</ProfileToken>
                                   <Translation>#{pan_tilt_zoom_vector translation}</Translation>"
@@ -58,8 +58,8 @@ defmodule EvercamMedia.ONVIFPTZ do
 	                                         end)
   end
  
-  def stop(host, port, username, password, profile_token) do
-    ptz_request(host, port,"Stop", 
+  def stop(url, username, password, profile_token) do
+    ptz_request(url, "Stop", 
                 "/env:Envelope/env:Body/tptz:StopResponse", 
                 username, password,
                 "<ProfileToken>#{profile_token}</ProfileToken>")
@@ -79,7 +79,7 @@ defmodule EvercamMedia.ONVIFPTZ do
     pan_tilt <> zoom
   end
 
-  defp ptz_request(host, port, method, xpath, username, password, parameters \\ "") do
-    ONVIFClient.onvif_call(host, port, :ptz, method, xpath, username, password, parameters) 
+  defp ptz_request(url, method, xpath, username, password, parameters \\ "") do
+    ONVIFClient.onvif_call(url, :ptz, method, xpath, username, password, parameters) 
   end
 end

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -12,7 +12,7 @@ defmodule EvercamMedia.ONVIFPTZ do
                 "/env:Envelope/env:Body/tptz:GetConfigurationsResponse", username, password)
   end
 
-  def get_presets(url, username, password, profile_token \\ "Profile_1") do
+  def get_presets(url, username, password, profile_token) do
     {:ok, response} = ptz_request(url, "GetPresets", 
                                   "/env:Envelope/env:Body/tptz:GetPresetsResponse", 
                                   username, password,
@@ -48,14 +48,61 @@ defmodule EvercamMedia.ONVIFPTZ do
   def relative_move(url, username, password, profile_token, translation, speed \\ []) do
     ptz_request(url, "RelativeMove", 
                 "/env:Envelope/env:Body/tptz:GotoPresetResponse",username, password,
-                                  "<ProfileToken>#{profile_token}</ProfileToken>
-                                  <Translation>#{pan_tilt_zoom_vector translation}</Translation>"
-		                              <> case pan_tilt_zoom_vector speed do
-                                                   "" -> ""
-		                                   vector -> "<Speed>#{vector}</Speed>"
-	                                         end)
+                "<ProfileToken>#{profile_token}</ProfileToken>
+                <Translation>#{pan_tilt_zoom_vector translation}</Translation>"
+	        <> case pan_tilt_zoom_vector speed do
+                     "" -> ""
+	             vector -> "<Speed>#{vector}</Speed>"
+	       end)
+  end
+
+  
+  
+  def continuous_move(url, username, password, profile_token, velocity \\ []) do
+    ptz_request(url, "ContinousMove", 
+                "/env:Envelope/env:Body/tptz:ContinuousMoveResponse", username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>"
+	        <> case pan_tilt_zoom_vector velocity do
+                     "" -> ""
+	             vector -> "<Velocity>#{vector}</Velocity>"
+               end)
+  end
+
+
+  def goto_home_position(url, username, password, profile_token, speed \\ []) do
+    ptz_request(url,"GotoHomePosition", 
+                "/env:Envelope/env:Body/tptz:GotoHomePositionResponse", username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>"
+                <> case pan_tilt_zoom_vector speed do
+                     "" -> ""
+	             vector -> "<Speed>#{vector}</Speed>"
+                end)
+
   end
  
+  def remove_preset(url, username, password, profile_token, preset_token) do
+    ptz_request(url, "RemovePreset", 
+                "/env:Envelope/env:Body/tptz:RemovePresetResponse", username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>
+                <PresetToken>#{preset_token}</PresetToken>")
+  end
+
+  def set_preset(url, username, password, profile_token, preset_token, preset_name) do
+    ptz_request(url, "SetPreset", 
+                "/env:Envelope/env:Body/tptz:SetPresetResponse", username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>
+                <PresetName>#{preset_name}</PresetName>
+                <PresetToken>#{preset_token}</PresetToken>")
+  end
+
+
+  def set_home_position(url, username, password, profile_token) do
+    ptz_request(url ,"SetHomePosition", 
+                "/env:Envelope/env:Body/tptz:SetHomePositionResponse", username, password,
+                "<ProfileToken>#{profile_token}</ProfileToken>")
+
+  end
+						 
   def stop(url, username, password, profile_token) do
     ptz_request(url, "Stop", 
                 "/env:Envelope/env:Body/tptz:StopResponse", 

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -59,7 +59,7 @@ defmodule EvercamMedia.ONVIFPTZ do
   
   
   def continuous_move(url, username, password, profile_token, velocity \\ []) do
-    ptz_request(url, "ContinousMove", 
+    ptz_request(url, "ContinuousMove", 
                 "/env:Envelope/env:Body/tptz:ContinuousMoveResponse", username, password,
                 "<ProfileToken>#{profile_token}</ProfileToken>"
 	        <> case pan_tilt_zoom_vector velocity do

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -47,7 +47,7 @@ defmodule EvercamMedia.ONVIFPTZ do
  
   def relative_move(url, username, password, profile_token, translation, speed \\ []) do
     ptz_request(url, "RelativeMove", 
-                "/env:Envelope/env:Body/tptz:GotoPresetResponse",username, password,
+                "/env:Envelope/env:Body/tptz:RelativeMoveResponse",username, password,
                 "<ProfileToken>#{profile_token}</ProfileToken>
                 <Translation>#{pan_tilt_zoom_vector translation}</Translation>"
 	        <> case pan_tilt_zoom_vector speed do

--- a/lib/onvif/onvif_ptz.ex
+++ b/lib/onvif/onvif_ptz.ex
@@ -20,12 +20,10 @@ defmodule EvercamMedia.ONVIFPTZ do
     {:ok, Map.put(%{}, 
                   "Presets",
                   response
-		  |>  Poison.Parser.parse!
                   |>  Map.get("Preset")
                   |>  Enum.filter(&(Map.get(&1, "Name") != nil))
           )
-          |> Poison.Encoder.encode(nil)
-          |> IO.iodata_to_binary}
+        }
   end
 
   def get_status(url, username, password, profile_token) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EvercamMedia.Mixfile do
     [app: :evercam_media,
      version: "1.0.0",
      elixir: "~> 1.0",
-     elixirc_paths: ["lib", "web"],
+     elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      compilers: [:phoenix] ++ Mix.compilers,
@@ -36,6 +36,11 @@ defmodule EvercamMedia.Mixfile do
     :timex,
     :uuid
   ]
+
+  # Specifies which paths to compile per environment
+  defp elixirc_paths(:test), do: ["lib", "web", "test/support"]
+  defp elixirc_paths(_),     do: ["lib", "web"]
+
 
   defp deps do
     [{:phoenix, "~> 0.13"},

--- a/test/controllers/onvifdevmgmt_controller_test.exs
+++ b/test/controllers/onvifdevmgmt_controller_test.exs
@@ -1,0 +1,9 @@
+defmodule EvercamMedia.ONVIFDeviceManagementControllerTest do
+  use EvercamMedia.ConnCase
+
+  test "GET /onvif/cameras/:camera_id/macaddr, returns MAC address" do
+    conn = get conn(), "/onvif/cameras/mobile-mast-test/macaddr"
+    assert (json_response(conn, 200) |> Map.get("mac_address")) == "44:19:b6:4b:f1:a2"
+  end
+
+end

--- a/test/controllers/onvifdevmgmt_controller_test.exs
+++ b/test/controllers/onvifdevmgmt_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule EvercamMedia.ONVIFDeviceManagementControllerTest do
   use EvercamMedia.ConnCase
 
-  test "GET /onvif/cameras/:camera_id/macaddr, returns MAC address" do
-    conn = get conn(), "/onvif/cameras/mobile-mast-test/macaddr"
+  test "GET /v1/cameras/:id/macaddr, returns MAC address" do
+    conn = get conn(), "/v1/cameras/mobile-mast-test/macaddr"
     assert (json_response(conn, 200) |> Map.get("mac_address")) == "44:19:b6:4b:f1:a2"
   end
 

--- a/test/controllers/onvifptz_controller_test.exs
+++ b/test/controllers/onvifptz_controller_test.exs
@@ -1,0 +1,12 @@
+defmodule EvercamMedia.ONVIFPTZControllerTest do
+  use EvercamMedia.ConnCase
+
+  test "GET /onvif/cameras/:camera_id/ptz/presets, gives something" do
+    conn = get conn(), "/onvif/cameras/:camera_id/ptz/presets", camera_id: "mobile-mast-test"
+    IO.puts inspect json_response(conn, 200) 
+  end
+
+
+
+
+end

--- a/test/controllers/onvifptz_controller_test.exs
+++ b/test/controllers/onvifptz_controller_test.exs
@@ -3,7 +3,8 @@ defmodule EvercamMedia.ONVIFPTZControllerTest do
 
   test "GET /onvif/cameras/:camera_id/ptz/presets, gives something" do
     conn = get conn(), "/onvif/cameras/mobile-mast-test/ptz/presets"
-    assert inspect json_response(conn, 200) =~ "Back Main Yard" 
+    assert json_response(conn, 200) 
+           |> Map.get("Presets") != nil
   end
 
 end

--- a/test/controllers/onvifptz_controller_test.exs
+++ b/test/controllers/onvifptz_controller_test.exs
@@ -2,11 +2,8 @@ defmodule EvercamMedia.ONVIFPTZControllerTest do
   use EvercamMedia.ConnCase
 
   test "GET /onvif/cameras/:camera_id/ptz/presets, gives something" do
-    conn = get conn(), "/onvif/cameras/:camera_id/ptz/presets", camera_id: "mobile-mast-test"
-    IO.puts inspect json_response(conn, 200) 
+    conn = get conn(), "/onvif/cameras/mobile-mast-test/ptz/presets"
+    assert inspect json_response(conn, 200) =~ "Back Main Yard" 
   end
-
-
-
 
 end

--- a/test/controllers/onvifptz_controller_test.exs
+++ b/test/controllers/onvifptz_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule EvercamMedia.ONVIFPTZControllerTest do
   use EvercamMedia.ConnCase
 
-  test "GET /onvif/cameras/:camera_id/ptz/presets, gives something" do
-    conn = get conn(), "/onvif/cameras/mobile-mast-test/ptz/presets"
+  test "GET /v1/cameras/:id/ptz/presets, gives something" do
+    conn = get conn(), "/v1/cameras/mobile-mast-test/ptz/presets"
     assert json_response(conn, 200) 
            |> Map.get("Presets") != nil
   end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule EvercamMedia.PageControllerTest do
+  use EvercamMedia.ConnCase
+
+  test "GET /" do
+    conn = get conn(), "/"
+    assert conn.resp_body =~ "<body>You are being <a href=\"http://www.evercam.io\">redirected</a>.</body>"
+  end
+
+  # test "GET /messages" do
+  #  conn = get conn(), "/messages"
+  #  assert html_response(conn, 200) =~ "Messages"
+  # end
+end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -6,8 +6,4 @@ defmodule EvercamMedia.PageControllerTest do
     assert conn.resp_body =~ "<body>You are being <a href=\"http://www.evercam.io\">redirected</a>.</body>"
   end
 
-  # test "GET /messages" do
-  #  conn = get conn(), "/messages"
-  #  assert html_response(conn, 200) =~ "Messages"
-  # end
 end

--- a/test/onvif/device_management_test.exs
+++ b/test/onvif/device_management_test.exs
@@ -4,32 +4,29 @@ defmodule DeviceManagementTest do
   
   test "get_system_date_and_time method on hikvision camera" do
     {:ok, response} = ONVIFDeviceManagement.get_system_date_and_time("http://149.13.244.32:8100", "admin", "mehcam")
-    assert Poison.Parser.parse!(response)
-             |> Map.get("Date")
-             |> Map.get("Year") == "2015"
+    assert response
+           |> Map.get("Date")
+           |> Map.get("Year") == "2015"
   end   
 
  test "get_device_information method on hikvision camera" do
     {:ok, response} = ONVIFDeviceManagement.get_device_information("http://149.13.244.32:8100", "admin", "mehcam")
-    result_map = Poison.Parser.parse!(response)
-
-    assert Map.get(result_map, "Manufacturer")  == "HIKVISION"
-    assert Map.get(result_map, "Model") == "DS-2DF7286-A"
-    assert Map.get(result_map, "FirmwareVersion") == "V5.1.8 build 140616"
-    assert Map.get(result_map, "SerialNumber") == "DS-2DF7286-A20140705CCWR471699220B"
-    assert Map.get(result_map, "HardwareId") == "88"
+    assert Map.get(response, "Manufacturer")  == "HIKVISION"
+    assert Map.get(response, "Model") == "DS-2DF7286-A"
+    assert Map.get(response, "FirmwareVersion") == "V5.1.8 build 140616"
+    assert Map.get(response, "SerialNumber") == "DS-2DF7286-A20140705CCWR471699220B"
+    assert Map.get(response, "HardwareId") == "88"
 
  end   
 
  test "get_network_interfaces method on hikvision camera" do
    {:ok, response} = ONVIFDeviceManagement.get_network_interfaces("http://149.13.244.32:8100", "admin", "mehcam")
-   result_map = Poison.Parser.parse!(response)
-   assert result_map
+   assert response
           |> Map.get("IPv4")
           |> Map.get("Config")
           |> Map.get("Manual")
           |> Map.get("Address") == "192.168.1.100"
-   assert result_map
+   assert response
           |> Map.get("Info")
           |> Map.get("HwAddress") == "44:19:b6:4b:f1:a2"
 

--- a/test/onvif/device_management_test.exs
+++ b/test/onvif/device_management_test.exs
@@ -3,14 +3,14 @@ defmodule DeviceManagementTest do
   alias EvercamMedia.ONVIFDeviceManagement
   
   test "get_system_date_and_time method on hikvision camera" do
-    {:ok, response} = ONVIFDeviceManagement.get_system_date_and_time("149.13.244.32", "8100", "admin", "mehcam")
+    {:ok, response} = ONVIFDeviceManagement.get_system_date_and_time("http://149.13.244.32:8100", "admin", "mehcam")
     assert Poison.Parser.parse!(response)
              |> Map.get("Date")
              |> Map.get("Year") == "2015"
   end   
 
  test "get_device_information method on hikvision camera" do
-    {:ok, response} = ONVIFDeviceManagement.get_device_information("149.13.244.32", "8100", "admin", "mehcam")
+    {:ok, response} = ONVIFDeviceManagement.get_device_information("http://149.13.244.32:8100", "admin", "mehcam")
     result_map = Poison.Parser.parse!(response)
 
     assert Map.get(result_map, "Manufacturer")  == "HIKVISION"
@@ -22,7 +22,7 @@ defmodule DeviceManagementTest do
  end   
 
  test "get_network_interfaces method on hikvision camera" do
-   {:ok, response} = ONVIFDeviceManagement.get_network_interfaces("149.13.244.32", "8100", "admin", "mehcam")
+   {:ok, response} = ONVIFDeviceManagement.get_network_interfaces("http://149.13.244.32:8100", "admin", "mehcam")
    result_map = Poison.Parser.parse!(response)
    assert result_map
           |> Map.get("IPv4")

--- a/test/onvif/device_management_test.exs
+++ b/test/onvif/device_management_test.exs
@@ -1,0 +1,38 @@
+defmodule DeviceManagementTest do
+  use ExUnit.Case
+  alias EvercamMedia.ONVIFDeviceManagement
+  
+  test "get_system_date_and_time method on hikvision camera" do
+    {:ok, response} = ONVIFDeviceManagement.get_system_date_and_time("149.13.244.32", "8100", "admin", "mehcam")
+    assert Poison.Parser.parse!(response)
+             |> Map.get("Date")
+             |> Map.get("Year") == "2015"
+  end   
+
+ test "get_device_information method on hikvision camera" do
+    {:ok, response} = ONVIFDeviceManagement.get_device_information("149.13.244.32", "8100", "admin", "mehcam")
+    result_map = Poison.Parser.parse!(response)
+
+    assert Map.get(result_map, "Manufacturer")  == "HIKVISION"
+    assert Map.get(result_map, "Model") == "DS-2DF7286-A"
+    assert Map.get(result_map, "FirmwareVersion") == "V5.1.8 build 140616"
+    assert Map.get(result_map, "SerialNumber") == "DS-2DF7286-A20140705CCWR471699220B"
+    assert Map.get(result_map, "HardwareId") == "88"
+
+ end   
+
+ test "get_network_interfaces method on hikvision camera" do
+   {:ok, response} = ONVIFDeviceManagement.get_network_interfaces("149.13.244.32", "8100", "admin", "mehcam")
+   result_map = Poison.Parser.parse!(response)
+   assert result_map
+          |> Map.get("IPv4")
+          |> Map.get("Config")
+          |> Map.get("Manual")
+          |> Map.get("Address") == "192.168.1.100"
+   assert result_map
+          |> Map.get("Info")
+          |> Map.get("HwAddress") == "44:19:b6:4b:f1:a2"
+
+  end   
+end
+

--- a/test/onvif/media_test.exs
+++ b/test/onvif/media_test.exs
@@ -3,7 +3,7 @@ defmodule MediaTest do
   alias EvercamMedia.ONVIFMedia
   
   test "get_profiles method on hikvision camera" do
-    {:ok, response} = ONVIFMedia.get_profiles("149.13.244.32", "8100", "admin", "mehcam")
+    {:ok, response} = ONVIFMedia.get_profiles("http://149.13.244.32:8100", "admin", "mehcam")
     [profile_1, profile_2, profile_3] = 
       Poison.Parser.parse!(response)
       |> Map.get("Profiles")

--- a/test/onvif/media_test.exs
+++ b/test/onvif/media_test.exs
@@ -4,9 +4,7 @@ defmodule MediaTest do
   
   test "get_profiles method on hikvision camera" do
     {:ok, response} = ONVIFMedia.get_profiles("http://149.13.244.32:8100", "admin", "mehcam")
-    [profile_1, profile_2, profile_3] = 
-      Poison.Parser.parse!(response)
-      |> Map.get("Profiles")
+    [profile_1, profile_2, profile_3] = Map.get(response, "Profiles")
     assert Map.get(profile_1, "token")  == "Profile_1"
     assert Map.get(profile_2, "token") == "Profile_2"
     assert Map.get(profile_3, "token") == "Profile_3"

--- a/test/onvif/media_test.exs
+++ b/test/onvif/media_test.exs
@@ -1,0 +1,16 @@
+defmodule MediaTest do
+  use ExUnit.Case
+  alias EvercamMedia.ONVIFMedia
+  
+  test "get_profiles method on hikvision camera" do
+    {:ok, response} = ONVIFMedia.get_profiles("149.13.244.32", "8100", "admin", "mehcam")
+    [profile_1, profile_2, profile_3] = 
+      Poison.Parser.parse!(response)
+      |> Map.get("Profiles")
+    assert Map.get(profile_1, "token")  == "Profile_1"
+    assert Map.get(profile_2, "token") == "Profile_2"
+    assert Map.get(profile_3, "token") == "Profile_3"
+  end 
+
+end
+

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -39,13 +39,10 @@ defmodule PTZTest do
     assert response == :ok
   end   
 
-  test "set_preset method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.set_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "99", "Jose's Preset")
-	  assert response |> Map.get("PresetToken") == "99"
-  end
-
-  test "remove_preset method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.remove_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "99")
+  test "set_preset and remove_preset method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.set_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
+	  preset_token = response |> Map.get("PresetToken")
+    {:ok, response} = ONVIFPTZ.remove_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", preset_token)
 	  assert response = :ok
   end
 

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -36,12 +36,33 @@ defmodule PTZTest do
 
   test "goto_preset method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.goto_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "6")
-    assert response == %{}
+    assert response == :ok
   end   
+
+  test "set_preset method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.set_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "99", "Jose's Preset")
+	  assert response |> Map.get("PresetToken") == "99"
+  end
+
+  test "remove_preset method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.remove_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "99")
+	  assert response = :ok
+  end
+
+  test "set_home_position method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.set_home_position("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
+	  assert response == :ok
+  end
+
+  test "goto_home_position method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.goto_home_position("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
+	  assert response == :ok
+  end   
+
   
   test "stop method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.stop("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
-    assert response == %{}
+    assert response == :ok
   end
 
   test "pan_tilt coordinates available" do

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -3,7 +3,7 @@ defmodule PTZTest do
   alias EvercamMedia.ONVIFPTZ
   
   test "get_nodes method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.get_nodes("149.13.244.32", "8100", "admin", "mehcam")
+    {:ok, response} = ONVIFPTZ.get_nodes("http://149.13.244.32:8100", "admin", "mehcam")
     result_map = Poison.Parser.parse!(response)
     assert  result_map 
             |> Map.get("PTZNode")
@@ -15,7 +15,7 @@ defmodule PTZTest do
    end 
 
   test "get_configurations method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.get_configurations("149.13.244.32", "8100", "admin", "mehcam")
+    {:ok, response} = ONVIFPTZ.get_configurations("http://149.13.244.32:8100", "admin", "mehcam")
     result_map = Poison.Parser.parse!(response)
     assert result_map
            |> Map.get("PTZConfiguration")
@@ -26,7 +26,7 @@ defmodule PTZTest do
   end 
 
   test "get_presets method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.get_presets("149.13.244.32", "8100", "admin", "mehcam", "Profile_1")
+    {:ok, response} = ONVIFPTZ.get_presets("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
     [first_preset | _] = 
       Poison.Parser.parse!(response)
       |> Map.get("Presets")
@@ -37,12 +37,12 @@ defmodule PTZTest do
   end   
 
   test "goto_preset method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.goto_preset("149.13.244.32", "8100", "admin", "mehcam", "Profile_1", "6")
+    {:ok, response} = ONVIFPTZ.goto_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "6")
     assert response == "{}"
   end   
   
   test "stop method on hikvision camera" do
-    {:ok, response} = ONVIFPTZ.stop("149.13.244.32", "8100", "admin", "mehcam", "Profile_1")
+    {:ok, response} = ONVIFPTZ.stop("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
     assert response == "{}"
   end
 

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -1,0 +1,80 @@
+defmodule PTZTest do
+  use ExUnit.Case
+  alias EvercamMedia.ONVIFPTZ
+  
+  test "get_nodes method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.get_nodes("149.13.244.32", "8100", "admin", "mehcam")
+    result_map = Poison.Parser.parse!(response)
+    assert  result_map 
+            |> Map.get("PTZNode")
+            |> Map.get("Name") == "PTZNODE"
+    
+    assert result_map 
+           |> Map.get("PTZNode")
+           |> Map.get("token") == "PTZNODETOKEN"
+   end 
+
+  test "get_configurations method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.get_configurations("149.13.244.32", "8100", "admin", "mehcam")
+    result_map = Poison.Parser.parse!(response)
+    assert result_map
+           |> Map.get("PTZConfiguration")
+           |> Map.get("Name") == "PTZ"
+    assert result_map
+           |> Map.get("PTZConfiguration")
+           |> Map.get("NodeToken") == "PTZNODETOKEN"
+  end 
+
+  test "get_presets method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.get_presets("149.13.244.32", "8100", "admin", "mehcam", "Profile_1")
+    [first_preset | _] = 
+      Poison.Parser.parse!(response)
+      |> Map.get("Presets")
+    assert first_preset 
+           |> Map.get("Name") == "Back Main Yard"
+    assert first_preset
+           |> Map.get("token") == "1"
+  end   
+
+  test "goto_preset method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.goto_preset("149.13.244.32", "8100", "admin", "mehcam", "Profile_1", "6")
+    assert response == "{}"
+  end   
+  
+  test "stop method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.stop("149.13.244.32", "8100", "admin", "mehcam", "Profile_1")
+    assert response == "{}"
+  end
+
+  test "pan_tilt coordinates available" do
+    response = ONVIFPTZ.pan_tilt_zoom_vector [x: 0.5671, y: 0.9919]
+    assert String.contains? response, "PanTilt"
+    assert not String.contains? response, "Zoom"
+  end
+
+  test "pan_tilt coordinates and zoom available" do
+    response = ONVIFPTZ.pan_tilt_zoom_vector [x: 0.5671, y: 0.9919, zoom: 1.0]
+    assert String.contains? response, "Zoom"
+    assert String.contains? response, "PanTilt" 
+  end
+
+  test "pan_tilt coordinates available broken but zoom ok" do
+    response = ONVIFPTZ.pan_tilt_zoom_vector [x: 0.5671, zoom: 0.9919]
+    assert String.contains? response, "Zoom"
+    assert not String.contains? response, "PanTilt"
+  end
+
+  test "pan_tilt_zoom only zoom available" do
+    response = ONVIFPTZ.pan_tilt_zoom_vector [zoom: 0.5671]
+    assert String.contains? response, "Zoom"
+    assert not String.contains? response, "PanTilt"
+  end
+
+  test "pan_tilt_zoom empty" do
+    response = ONVIFPTZ.pan_tilt_zoom_vector []
+    assert not String.contains? response, "Zoom"
+    assert not String.contains? response, "PanTilt" 
+  end
+
+end
+

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -58,6 +58,8 @@ defmodule PTZTest do
 
   
   test "stop method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.continuous_move("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", [x: 0.1, y: 0.0])
+    assert response == :ok
     {:ok, response} = ONVIFPTZ.stop("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
     assert response == :ok
   end

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -4,23 +4,21 @@ defmodule PTZTest do
   
   test "get_nodes method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.get_nodes("http://149.13.244.32:8100", "admin", "mehcam")
-    result_map = Poison.Parser.parse!(response)
-    assert  result_map 
-            |> Map.get("PTZNode")
-            |> Map.get("Name") == "PTZNODE"
+    assert response 
+           |> Map.get("PTZNode")
+           |> Map.get("Name") == "PTZNODE"
     
-    assert result_map 
+    assert response 
            |> Map.get("PTZNode")
            |> Map.get("token") == "PTZNODETOKEN"
    end 
 
   test "get_configurations method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.get_configurations("http://149.13.244.32:8100", "admin", "mehcam")
-    result_map = Poison.Parser.parse!(response)
-    assert result_map
+    assert response
            |> Map.get("PTZConfiguration")
            |> Map.get("Name") == "PTZ"
-    assert result_map
+    assert response
            |> Map.get("PTZConfiguration")
            |> Map.get("NodeToken") == "PTZNODETOKEN"
   end 
@@ -28,7 +26,7 @@ defmodule PTZTest do
   test "get_presets method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.get_presets("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
     [first_preset | _] = 
-      Poison.Parser.parse!(response)
+      response
       |> Map.get("Presets")
     assert first_preset 
            |> Map.get("Name") == "Back Main Yard"
@@ -38,12 +36,12 @@ defmodule PTZTest do
 
   test "goto_preset method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.goto_preset("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", "6")
-    assert response == "{}"
+    assert response == %{}
   end   
   
   test "stop method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.stop("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1")
-    assert response == "{}"
+    assert response == %{}
   end
 
   test "pan_tilt coordinates available" do

--- a/test/onvif/ptz_test.exs
+++ b/test/onvif/ptz_test.exs
@@ -56,6 +56,10 @@ defmodule PTZTest do
 	  assert response == :ok
   end   
 
+  test "relative_move method on hikvision camera" do
+    {:ok, response} = ONVIFPTZ.relative_move("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", [x: 0.0, y: 0.0, zoom: 0.0])
+	  assert response == :ok
+  end   
   
   test "stop method on hikvision camera" do
     {:ok, response} = ONVIFPTZ.continuous_move("http://149.13.244.32:8100", "admin", "mehcam", "Profile_1", [x: 0.1, y: 0.0])

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,0 +1,45 @@
+defmodule EvercamMedia.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Such tests rely on `Phoenix.ConnTest` and also
+  imports other functionalities to make it easier
+  to build and query models.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with connections
+      use Phoenix.ConnTest
+
+      # Alias the data repository and import query/model functions
+      alias EvercamMedia.Repo
+      alias EvercamMedia.Message
+      alias EvercamMedia.Endpoint
+      import Ecto.Model
+      import Ecto.Query, only: [from: 2]
+
+      # Import URL helpers from the router
+      import EvercamMedia.Router.Helpers
+
+      # The default endpoint for testing
+      @endpoint EvercamMedia.Endpoint
+    end
+  end
+
+  setup tags do
+    unless tags[:async] do
+      Ecto.Adapters.SQL.restart_test_transaction(EvercamMedia.Repo, [])
+    end
+
+    :ok
+  end
+end

--- a/web/controllers/onvifdevmgmt_controller.ex
+++ b/web/controllers/onvifdevmgmt_controller.ex
@@ -1,0 +1,29 @@
+defmodule EvercamMedia.ONVIFDeviceManagementController do
+  use Phoenix.Controller
+  alias EvercamMedia.Repo
+  alias EvercamMedia.ONVIFDeviceManagement
+  require Logger
+  plug :action
+
+  def macaddr(conn, params) do
+    camera = Repo.one! Camera.by_exid(params["camera_id"])
+    url = Camera.external_url camera
+    [username, password] =
+      camera 
+      |> Camera.auth
+      |> String.split ":"
+    {:ok, response} = ONVIFDeviceManagement.get_network_interfaces(url, username, password) 
+    mac_address = response 
+                  |> Poison.Parser.parse!
+                  |> Map.get("Info")
+                  |> Map.get("HwAddress")     
+    macaddr_respond(conn, 200, mac_address)
+  end
+
+  defp macaddr_respond(conn, code, mac_address) do
+    conn
+    |> put_status(code) 
+    |> put_resp_header("access-control-allow-origin", "*")
+    |> json %{mac_address: mac_address}
+  end
+end

--- a/web/controllers/onvifdevmgmt_controller.ex
+++ b/web/controllers/onvifdevmgmt_controller.ex
@@ -6,7 +6,7 @@ defmodule EvercamMedia.ONVIFDeviceManagementController do
   plug :action
 
   def macaddr(conn, params) do
-    camera = Repo.one! Camera.by_exid(params["camera_id"])
+    camera = Repo.one! Camera.by_exid(params["id"])
     url = Camera.external_url camera
     [username, password] =
       camera 

--- a/web/controllers/onvifdevmgmt_controller.ex
+++ b/web/controllers/onvifdevmgmt_controller.ex
@@ -14,7 +14,6 @@ defmodule EvercamMedia.ONVIFDeviceManagementController do
       |> String.split ":"
     {:ok, response} = ONVIFDeviceManagement.get_network_interfaces(url, username, password) 
     mac_address = response 
-                  |> Poison.Parser.parse!
                   |> Map.get("Info")
                   |> Map.get("HwAddress")     
     macaddr_respond(conn, 200, mac_address)

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -6,22 +6,61 @@ defmodule EvercamMedia.ONVIFPTZController do
   plug :action
 
   def presets(conn, params) do
-    camera = Repo.one! Camera.by_exid(params["camera_id"])
-    url = Camera.external_url camera
-    [username, password] =
-      camera 
-      |> Camera.auth
-      |> String.split ":"
-    {:ok, response} = ONVIFPTZ.get_presets(url, username, password)    
-    presets_respond(conn, 200, response)
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.get_presets(url, username, password, "Profile_1")    
+    default_respond(conn, 200, response)
   end
 
-  defp presets_respond(conn, code, response) do
+  def stop(conn, params) do
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.stop(url, username, password, "Profile_1")    
+    default_respond(conn, 200, response)
+  end
+
+  def home(conn, params) do
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.goto_home_position(url, username, password, "Profile_1")    
+    default_respond(conn, 200, response)
+  end
+
+  def sethome(conn, params) do
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.set_home_position(url, username, password, "Profile_1")    
+    default_respond(conn, 200, response)
+  end
+
+   def gotopreset(conn, params) do
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.goto_preset(url, username, password, 
+                                           "Profile_1", params["preset_token"])    
+    default_respond(conn, 200, response)
+  end
+
+  def setpreset(conn, params) do
+    [url, username, password] = get_camera_info(params["camera_id"])
+    {:ok, response} = ONVIFPTZ.set_preset(url, username, 
+                                                 password, "Profile_1",
+                                                 params["preset_token"],
+                                                 "Test")    
+    default_respond(conn, 200, response)
+  end
+
+  defp default_respond(conn, code, response) do
     conn
     |> put_status(code)
     |> put_resp_header("access-control-allow-origin", "*")
     |> json response
   end
    
+
+  defp get_camera_info(camera_id) do
+    camera = Repo.one! Camera.by_exid(camera_id)
+    url = Camera.external_url camera
+    [username, password] =
+      camera 
+      |> Camera.auth
+      |> String.split ":"
+    [url, username, password]
+  end
 
 end

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -58,6 +58,34 @@ defmodule EvercamMedia.ONVIFPTZController do
     default_respond(conn, 200, response)
   end
 
+  def continuousmove(conn, params) do
+    [url, username, password] = get_camera_info(params["id"])
+    velocity = case params["direction"] do
+                 "left" -> [x: -0.1, y: 0.0]
+                 "right" -> [x: 0.1, y: 0.0]
+                 "up" -> [x: 0.0, y: 0.1]
+                 "down" -> [x: 0.0, y: -0.1]
+                  _ -> [x: 0.0, y: 0.0]
+    end 
+    {:ok, response} = ONVIFPTZ.continuous_move(url, username, 
+                                               password, "Profile_1",
+                                               velocity)
+    default_respond(conn, 200, response)
+  end
+
+   def continuouszoom(conn, params) do
+    [url, username, password] = get_camera_info(params["id"])
+    velocity = case params["mode"] do
+                 "in" -> [zoom: 0.01]
+                 "out" -> [zoom: -0.01]
+                  _ -> [zoom: 0.0]
+    end 
+    {:ok, response} = ONVIFPTZ.continuous_move(url, username, 
+                                               password, "Profile_1",
+                                               velocity)
+    default_respond(conn, 200, response)
+  end
+
   defp default_respond(conn, code, response) do
     conn
     |> put_status(code)

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -86,6 +86,21 @@ defmodule EvercamMedia.ONVIFPTZController do
     default_respond(conn, 200, response)
   end
 
+  def relativemove(conn, params) do
+    [url, username, password] = get_camera_info(params["id"])
+    x = max(Map.get(params, "left", "0"), Map.get(params, "right","0")) |> String.to_integer
+    y = max(Map.get(params, "up", "0"), Map.get(params, "down","0")) |> String.to_integer
+    zoom = Map.get(params, "zoom", "0") |> String.to_integer
+    # If x value comes from "left" parameter make it negative
+    x = if Map.get(params, "left") == nil do x else -x end
+    # If y value comes from down make it negative
+    y = if Map.get(params, "up") == nil do y else -y end
+    {:ok, response} = ONVIFPTZ.relative_move(url, username, 
+                                               password, "Profile_1",
+                                               [x: x / 100.0, y: y / 100.0, zoom: zoom / 100.0])
+    default_respond(conn, 200, response)
+  end
+
   defp default_respond(conn, code, response) do
     conn
     |> put_status(code)

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -1,0 +1,27 @@
+defmodule EvercamMedia.ONVIFPTZController do
+  use Phoenix.Controller
+  alias EvercamMedia.Repo
+  alias EvercamMedia.ONVIFPTZ
+  require Logger
+  plug :action
+
+  def presets(conn, params) do
+    camera = Repo.one! Camera.by_exid(params["camera_id"])
+    url = Camera.external_url camera
+    [username, password] =
+      camera 
+      |> Camera.auth
+      |> String.split ":"
+    {:ok, response} = ONVIFPTZ.get_presets(url, username, password)    
+    presets_respond(conn, 200, response)
+  end
+
+  defp presets_respond(conn, code, response) do
+    conn
+    |> put_status(code)
+    |> put_resp_header("access-control-allow-origin", "*")
+    |> json response
+  end
+   
+
+end

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -6,25 +6,25 @@ defmodule EvercamMedia.ONVIFPTZController do
   plug :action
 
   def presets(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.get_presets(url, username, password, "Profile_1")    
     default_respond(conn, 200, response)
   end
 
   def stop(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.stop(url, username, password, "Profile_1")    
     default_respond(conn, 200, response)
   end
 
   def home(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.goto_home_position(url, username, password, "Profile_1")    
     default_respond(conn, 200, response)
   end
 
   def sethome(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.set_home_position(url, username, password, "Profile_1")    
     default_respond(conn, 200, response)
   end
@@ -37,11 +37,11 @@ defmodule EvercamMedia.ONVIFPTZController do
   end
 
   def setpreset(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.set_preset(url, username, 
                                                  password, "Profile_1",
-                                                 params["preset_token"],
-                                                 "Test")    
+                                                 "Test Preset",
+                                                 params["preset_token"])
     default_respond(conn, 200, response)
   end
 

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -5,6 +5,12 @@ defmodule EvercamMedia.ONVIFPTZController do
   require Logger
   plug :action
 
+  def status(conn, params) do
+    [url, username, password] = get_camera_info(params["id"])
+    {:ok, response} = ONVIFPTZ.get_status(url, username, password, "Profile_1")    
+    default_respond(conn, 200, response)
+  end
+
   def presets(conn, params) do
     [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.get_presets(url, username, password, "Profile_1")    
@@ -40,8 +46,15 @@ defmodule EvercamMedia.ONVIFPTZController do
     [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.set_preset(url, username, 
                                                  password, "Profile_1",
-                                                 "Test Preset",
-                                                 params["preset_token"])
+                                                 "", params["preset_token"])
+    default_respond(conn, 200, response)
+  end
+
+  def createpreset(conn, params) do
+    [url, username, password] = get_camera_info(params["id"])
+    {:ok, response} = ONVIFPTZ.set_preset(url, username, 
+                                                 password, "Profile_1",
+                                                 params["preset_name"])
     default_respond(conn, 200, response)
   end
 

--- a/web/controllers/onvifptz_controller.ex
+++ b/web/controllers/onvifptz_controller.ex
@@ -36,7 +36,7 @@ defmodule EvercamMedia.ONVIFPTZController do
   end
 
    def gotopreset(conn, params) do
-    [url, username, password] = get_camera_info(params["camera_id"])
+    [url, username, password] = get_camera_info(params["id"])
     {:ok, response} = ONVIFPTZ.goto_preset(url, username, password, 
                                            "Profile_1", params["preset_token"])    
     default_respond(conn, 200, response)

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,8 @@ defmodule EvercamMedia.Router do
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
     get "/onvif/cameras/:camera_id/ptz/presets", ONVIFPTZController, :presets
+    
+    get "/onvif/cameras/:camera_id/macaddr", ONVIFDeviceManagementController, :macaddr
 
     get "/live/:camera_id/index.m3u8", StreamController, :hls
     get "/live/:camera_id/:filename", StreamController, :ts

--- a/web/router.ex
+++ b/web/router.ex
@@ -16,6 +16,8 @@ defmodule EvercamMedia.Router do
     get "/v1/cameras/:id/live/snapshot", SnapshotController, :show
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
+    # get "/onvif/cameras/:id/ptz/presets", ONVIFPTZController, :presets
+
     get "/live/:camera_id/index.m3u8", StreamController, :hls
     get "/live/:camera_id/:filename", StreamController, :ts
     get "/on_play", StreamController, :rtmp

--- a/web/router.ex
+++ b/web/router.ex
@@ -26,6 +26,7 @@ defmodule EvercamMedia.Router do
     post "/v1/cameras/:id/ptz/continuous/start/:direction", ONVIFPTZController, :continuousmove
     post "/v1/cameras/:id/ptz/continuous/zoom/:mode", ONVIFPTZController, :continuouszoom
     post "/v1/cameras/:id/ptz/continuous/stop", ONVIFPTZController, :stop
+    post "/v1/cameras/:id/ptz/relative", ONVIFPTZController, :relativemove
     
     get "/v1/cameras/:id/macaddr", ONVIFDeviceManagementController, :macaddr
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -23,7 +23,9 @@ defmodule EvercamMedia.Router do
     post "/v1/cameras/:id/ptz/presets/:preset_token", ONVIFPTZController, :setpreset
     post "/v1/cameras/:id/ptz/presets/create/:preset_name", ONVIFPTZController, :createpreset
     post "/v1/cameras/:id/ptz/presets/go/:preset_token", ONVIFPTZController, :gotopreset
-    post "/v1/cameras/:id/ptz/stop", ONVIFPTZController, :stop
+    post "/v1/cameras/:id/ptz/continuous/start/:direction", ONVIFPTZController, :continuousmove
+    post "/v1/cameras/:id/ptz/continuous/zoom/:mode", ONVIFPTZController, :continuouszoom
+    post "/v1/cameras/:id/ptz/continuous/stop", ONVIFPTZController, :stop
     
     get "/v1/cameras/:id/macaddr", ONVIFDeviceManagementController, :macaddr
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -16,14 +16,14 @@ defmodule EvercamMedia.Router do
     get "/v1/cameras/:id/live/snapshot", SnapshotController, :show
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
-    get "/onvif/cameras/:camera_id/ptz/presets", ONVIFPTZController, :presets
-    post "/onvif/cameras/:camera_id/ptz/home", ONVIFPTZController, :home
-    post "/onvif/cameras/:camera_id/ptz/home/set", ONVIFPTZController, :sethome
-    post "/onvif/cameras/:camera_id/ptz/presets/:preset_token", ONVIFPTZController, :setpreset
-    post "/onvif/cameras/:camera_id/ptz/presets/go/:preset_token", ONVIFPTZController, :gotopreset
-    post "/onvif/cameras/:camera_id/ptz/stop", ONVIFPTZController, :stop
+    get "/v1/cameras/:id/ptz/presets", ONVIFPTZController, :presets
+    post "/v1/cameras/:id/ptz/home", ONVIFPTZController, :home
+    post "/v1/cameras/:id/ptz/home/set", ONVIFPTZController, :sethome
+    post "/v1/cameras/:id/ptz/presets/:preset_token", ONVIFPTZController, :setpreset
+    post "/v1/cameras/:id/ptz/presets/go/:preset_token", ONVIFPTZController, :gotopreset
+    post "/v1/cameras/:id/ptz/stop", ONVIFPTZController, :stop
     
-    get "/onvif/cameras/:camera_id/macaddr", ONVIFDeviceManagementController, :macaddr
+    get "/v1/cameras/:id/macaddr", ONVIFDeviceManagementController, :macaddr
 
     get "/live/:camera_id/index.m3u8", StreamController, :hls
     get "/live/:camera_id/:filename", StreamController, :ts

--- a/web/router.ex
+++ b/web/router.ex
@@ -16,10 +16,12 @@ defmodule EvercamMedia.Router do
     get "/v1/cameras/:id/live/snapshot", SnapshotController, :show
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
+    get "/v1/cameras/:id/ptz/status", ONVIFPTZController, :status
     get "/v1/cameras/:id/ptz/presets", ONVIFPTZController, :presets
     post "/v1/cameras/:id/ptz/home", ONVIFPTZController, :home
     post "/v1/cameras/:id/ptz/home/set", ONVIFPTZController, :sethome
     post "/v1/cameras/:id/ptz/presets/:preset_token", ONVIFPTZController, :setpreset
+    post "/v1/cameras/:id/ptz/presets/create/:preset_name", ONVIFPTZController, :createpreset
     post "/v1/cameras/:id/ptz/presets/go/:preset_token", ONVIFPTZController, :gotopreset
     post "/v1/cameras/:id/ptz/stop", ONVIFPTZController, :stop
     

--- a/web/router.ex
+++ b/web/router.ex
@@ -16,7 +16,7 @@ defmodule EvercamMedia.Router do
     get "/v1/cameras/:id/live/snapshot", SnapshotController, :show
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
-    # get "/onvif/cameras/:id/ptz/presets", ONVIFPTZController, :presets
+    get "/onvif/cameras/:camera_id/ptz/presets", ONVIFPTZController, :presets
 
     get "/live/:camera_id/index.m3u8", StreamController, :hls
     get "/live/:camera_id/:filename", StreamController, :ts

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,11 @@ defmodule EvercamMedia.Router do
     post "/v1/cameras/:id/recordings/snapshots", SnapshotController, :create
 
     get "/onvif/cameras/:camera_id/ptz/presets", ONVIFPTZController, :presets
+    post "/onvif/cameras/:camera_id/ptz/home", ONVIFPTZController, :home
+    post "/onvif/cameras/:camera_id/ptz/home/set", ONVIFPTZController, :sethome
+    post "/onvif/cameras/:camera_id/ptz/presets/:preset_token", ONVIFPTZController, :setpreset
+    post "/onvif/cameras/:camera_id/ptz/presets/go/:preset_token", ONVIFPTZController, :gotopreset
+    post "/onvif/cameras/:camera_id/ptz/stop", ONVIFPTZController, :stop
     
     get "/onvif/cameras/:camera_id/macaddr", ONVIFDeviceManagementController, :macaddr
 


### PR DESCRIPTION
Hi Milos
Very first cut. Error handling is non existent. The goal is to have something for Liuting to start working in the UI. Tests are coded against a camera called mobile-mast-test that is really the mobile-mast camera available at http://149.13.244.32:8100. I have manually added it myself to my environment. Feel free of not merging the tests as they won't work in anyone else environment! One fix for this would be to add this camera to the default DB shipped with the environment. 
I forgot to add the delete route, but better not to mess with the code until reviewed and merged. I takes only 5 mins to add it as the method is available in the lib/onvif_ptz.ex file.
Cheers,
Jose