### PR TITLE
Authentication based on API_ID and API_KEY parameters

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -31,7 +31,7 @@ config :evercam_media, EvercamMedia.Endpoint,
 config :logger, level: :warn
 
 # Filter out these fields from the logs
-config :phoenix, :filter_parameters, ["password", "api_id", "api_key"]
+config :phoenix, :filter_parameters, ["password", "api_key"]
 
 # ## Using releases
 #

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -30,6 +30,9 @@ config :evercam_media, EvercamMedia.Endpoint,
 # Do not print debug messages in production
 config :logger, level: :warn
 
+# Filter out these fields from the logs
+config :phoenix, :filter_parameters, ["password", "api_id", "api_key"]
+
 # ## Using releases
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/evercam_media/auth.ex
+++ b/lib/evercam_media/auth.ex
@@ -1,0 +1,18 @@
+defmodule EvercamMedia.Auth do
+  def validate(api_id, api_key) do
+    if present?(api_id) && present?(api_key) do
+      case EvercamMedia.Repo.one(User.find_by_api_keys(api_id, api_key)) do
+        %User{} ->
+          :valid
+        nil ->
+          :invalid
+      end
+    else
+      :invalid
+    end
+  end
+
+  defp present?(str) do
+    is_binary(str) && str != ""
+  end
+end

--- a/test/controllers/authentication_plug_test.exs
+++ b/test/controllers/authentication_plug_test.exs
@@ -16,11 +16,11 @@ defmodule EvercamMedia.AuthenticationPlugTest do
         username: "paulm", password: "whatever", email: "paul@mccartney.com", 
         api_id: "some_api_id", api_key: "some_api_key", country_id: country.id})
 
-    c = conn(:put, "/v1/users/#{user.id}?api_id=#{user.api_id}&api_key=#{user.api_key}", %{ "user" => %{ firstname: "whatever" }} )
+    conn = conn(:put, "/v1/users/#{user.id}?api_id=#{user.api_id}&api_key=#{user.api_key}", %{ "user" => %{ firstname: "whatever" }} )
       |> EvercamMedia.Router.call(@opts)
 
-    assert c.state == :sent
-    assert c.status == 200
+    assert conn.state == :sent
+    assert conn.status == 200
   end
 
   test "returns HTTP 200 if x-api-key and x-api-id headers are valid" do
@@ -29,12 +29,12 @@ defmodule EvercamMedia.AuthenticationPlugTest do
         username: "paulm", password: "whatever", email: "paul@mccartney.com", 
         api_id: "some_api_id", api_key: "some_api_key", country_id: country.id})
 
-    c = conn(:put, "/v1/users/#{user.id}", %{ "user" => %{ firstname: "whatever" }} )
+    conn = conn(:put, "/v1/users/#{user.id}", %{ "user" => %{ firstname: "whatever" }} )
       |> Plug.Conn.put_req_header("x-api-key", user.api_key)
       |> Plug.Conn.put_req_header("x-api-id", user.api_id)
       |> EvercamMedia.Router.call(@opts)
 
-    assert c.state == :sent
-    assert c.status == 200
+    assert conn.state == :sent
+    assert conn.status == 200
   end
 end

--- a/test/controllers/authentication_plug_test.exs
+++ b/test/controllers/authentication_plug_test.exs
@@ -1,0 +1,27 @@
+defmodule EvercamMedia.AuthenticationPlugTest do
+  use EvercamMedia.PlugCase
+
+  test "returns HTTP 401 with error message if api_id and api_key are invalid" do
+    conn = conn(:put, "/v1/users")
+    conn = EvercamMedia.Router.call(conn, @opts)
+
+    assert conn.state == :sent
+    assert conn.status == 401
+    assert Poison.decode!(conn.resp_body) == %{"error" => %{"message" => "Invalid API keys"}}
+  end
+
+  test "returns HTTP 200 if api_id and api_key are valid" do
+    {:ok, country} = EvercamMedia.Repo.insert(%Country{name: "Whatever", iso3166_a2: "WHT"})
+    {:ok, user} = EvercamMedia.Repo.insert(%User{ firstname: "Paul", lastname: "McCartney", 
+        username: "paulm", password: "whatever", email: "paul@mccartney.com", 
+        api_id: "some_api_id", api_key: "some_api_key", country_id: country.id})
+
+    c = conn(:put, "/v1/users/#{user.id}", %{ "user" => %{ firstname: "whatever" }} )
+      |> Plug.Conn.put_req_header("x-api-key", user.api_key)
+      |> Plug.Conn.put_req_header("x-api-id", user.api_id)
+      |> EvercamMedia.Router.call(@opts)
+
+    assert c.state == :sent
+    assert c.status == 200
+  end
+end

--- a/test/controllers/authentication_plug_test.exs
+++ b/test/controllers/authentication_plug_test.exs
@@ -2,7 +2,7 @@ defmodule EvercamMedia.AuthenticationPlugTest do
   use EvercamMedia.PlugCase
 
   test "returns HTTP 401 with error message if api_id and api_key are invalid" do
-    conn = conn(:put, "/v1/users")
+    conn = conn(:put, "/v1/users/1")
     conn = EvercamMedia.Router.call(conn, @opts)
 
     assert conn.state == :sent
@@ -10,7 +10,20 @@ defmodule EvercamMedia.AuthenticationPlugTest do
     assert Poison.decode!(conn.resp_body) == %{"error" => %{"message" => "Invalid API keys"}}
   end
 
-  test "returns HTTP 200 if api_id and api_key are valid" do
+  test "returns HTTP 200 if api_id and api_key query strings are valid" do
+    {:ok, country} = EvercamMedia.Repo.insert(%Country{name: "Whatever", iso3166_a2: "WHT"})
+    {:ok, user} = EvercamMedia.Repo.insert(%User{ firstname: "Paul", lastname: "McCartney", 
+        username: "paulm", password: "whatever", email: "paul@mccartney.com", 
+        api_id: "some_api_id", api_key: "some_api_key", country_id: country.id})
+
+    c = conn(:put, "/v1/users/#{user.id}?api_id=#{user.api_id}&api_key=#{user.api_key}", %{ "user" => %{ firstname: "whatever" }} )
+      |> EvercamMedia.Router.call(@opts)
+
+    assert c.state == :sent
+    assert c.status == 200
+  end
+
+  test "returns HTTP 200 if x-api-key and x-api-id headers are valid" do
     {:ok, country} = EvercamMedia.Repo.insert(%Country{name: "Whatever", iso3166_a2: "WHT"})
     {:ok, user} = EvercamMedia.Repo.insert(%User{ firstname: "Paul", lastname: "McCartney", 
         username: "paulm", password: "whatever", email: "paul@mccartney.com", 

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -69,4 +69,22 @@ defmodule EvercamMedia.UserControllerTest do
 
     refute response["user"]["confirmed_at"] == ""
   end
+
+  test "PUT /v1/users/:id - updates the User with the supplied id" do
+    {:ok, country} = EvercamMedia.Repo.insert(%Country{ name: "Whatever", iso3166_a2: "WHTEVR" })
+    {:ok, user} =  EvercamMedia.Repo.insert(%User{firstname: "John" , lastname: "Doe", 
+        email: "johndoe@example.com", username: "johnd", country_id: country.id, 
+        password: "some_password", api_id: "api_id", api_key: "api_key"})
+    params = %{"user" => %{ firstname: "Jonnathan" }}
+
+    conn = conn()
+      |> Plug.Conn.put_req_header("x-api-id", user.api_id)
+      |> Plug.Conn.put_req_header("x-api-key", user.api_key)
+      |> put("/v1/users/#{user.id}", params)
+
+    response = json_response(conn, 200)
+
+    assert response["user"]["firstname"] == "Jonnathan"
+    assert response["user"]["lastname"] == "Doe"
+  end
 end

--- a/test/evercam_media/auth_test.exs
+++ b/test/evercam_media/auth_test.exs
@@ -1,0 +1,26 @@
+defmodule EvercamMedia.AuthTest do
+  use EvercamMedia.ModelCase
+
+  # EvercamMedia.Auth.validate/2
+
+  setup do
+    {:ok, country } = Repo.insert(%Country{name: "Whatever", iso3166_a2: "WHTEVR"})
+    {:ok, user} = Repo.insert(%User{firstname: "Jake", lastname: "Doe",
+      email: "jake@doe.com", api_id: UUID.uuid4(:hex), api_key: UUID.uuid4(:hex),
+      username: "jake_doe", password: "whatever123", country_id: country.id})
+
+    { :ok, country: country, user: user }
+  end
+
+  test "returns :valid if api_id and api_key are valid", context do
+    assert EvercamMedia.Auth.validate(context[:user].api_id, context[:user].api_key) == :valid
+  end
+
+  test "returns :invalid if api_id and api_key are invalid" do
+    assert EvercamMedia.Auth.validate("some_invalid_api_id", "some_invalid_api_key") == :invalid
+  end
+
+  test "returns :invalid if api_id and api_key are missing" do
+    assert EvercamMedia.Auth.validate("", "") == :invalid
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,8 +39,8 @@ defmodule EvercamMedia.ConnCase do
     # Wrap this case in a transaction
     Ecto.Adapters.SQL.begin_test_transaction(EvercamMedia.Repo)
 
-    camera = %Camera{config: %{"auth" => %{"basic" => %{"password" => "mehcam", "username" => "admin"}}, "external_host" => "149.13.244.32", "external_http_port" => 8100, "external_rtsp_port" => 9100, "internal_host" => "", "internal_http_port" => "", "internal_rtsp_port" => "", "snapshots" => %{"jpg" => "/Streaming/Channels/1/picture"}}, exid: "mobile-mast-test", id: 5, is_online: true, is_public: false, name: "Test Mobile Mast", owner_id: 2}
-    EvercamMedia.Repo.insert(camera)
+    #camera = %Camera{config: %{"auth" => %{"basic" => %{"password" => "mehcam", "username" => "admin"}}, "external_host" => "149.13.244.32", "external_http_port" => 8100, "external_rtsp_port" => 9100, "internal_host" => "", "internal_http_port" => "", "internal_rtsp_port" => "", "snapshots" => %{"jpg" => "/Streaming/Channels/1/picture"}}, exid: "mobile-mast-test", id: 5, is_online: true, is_public: false, name: "Test Mobile Mast", owner_id: 2}
+    #EvercamMedia.Repo.insert(camera)
 
     # Roll it back once we are done
     on_exit fn ->

--- a/test/support/plug_case.ex
+++ b/test/support/plug_case.ex
@@ -1,0 +1,38 @@
+defmodule EvercamMedia.PlugCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Such tests rely on `Phoenix.ConnTest` and also
+  imports other functionalities to make it easier
+  to build and query models.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use ExUnit.Case, async: false
+      use Plug.Test
+
+      @opts EvercamMedia.Router.init([])
+    end
+  end
+
+  setup do
+    # Wrap this case in a transaction
+    Ecto.Adapters.SQL.begin_test_transaction(EvercamMedia.Repo)
+
+    # Roll it back once we are done
+    on_exit fn ->
+      Ecto.Adapters.SQL.rollback_test_transaction(EvercamMedia.Repo)
+    end
+
+    :ok
+  end
+end

--- a/web/controllers/authentication_plug.ex
+++ b/web/controllers/authentication_plug.ex
@@ -1,0 +1,25 @@
+defmodule EvercamMedia.AuthenticationPlug do
+  import Plug.Conn
+
+  def init(_opts) do
+  end
+  
+  def call(conn, _) do
+    api_key = conn
+              |> Plug.Conn.get_req_header("x-api-key")
+              |> List.first
+    api_id = conn
+             |> Plug.Conn.get_req_header("x-api-id")
+             |> List.first
+
+    case EvercamMedia.Auth.validate(api_id, api_key) do
+      :valid ->
+        conn
+      :invalid ->
+        conn
+        |> resp(401, Poison.encode!(%{ error: %{ message: "Invalid API keys" }}, []))
+        |> send_resp()
+        |> halt()
+    end
+  end
+end

--- a/web/controllers/authentication_plug.ex
+++ b/web/controllers/authentication_plug.ex
@@ -19,17 +19,17 @@ defmodule EvercamMedia.AuthenticationPlug do
     end
   end
 
-  defp extract_api_credential(c, %{ header: header_name, query: query_string_name }) do
-    extract_credential_from_query_string(c, query_string_name) || extract_credential_from_header(c, header_name)
+  defp extract_api_credential(conn, %{ header: header_name, query: query_string_name }) do
+    extract_credential_from_query_string(conn, query_string_name) || extract_credential_from_header(conn, header_name)
   end
 
-  defp extract_credential_from_query_string(c, query_string_name) do
-   Plug.Conn.fetch_query_params(c, query_string_name)
+  defp extract_credential_from_query_string(conn, query_string_name) do
+   Plug.Conn.fetch_query_params(conn, query_string_name)
    Map.get(c.params, query_string_name, nil)
   end
 
-  defp extract_credential_from_header(c, header_name) do
-    c 
+  defp extract_credential_from_header(conn, header_name) do
+    conn
     |> Plug.Conn.get_req_header(header_name)
     |> List.first
   end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -11,7 +11,19 @@ defmodule EvercamMedia.UserController do
     handle_user_signup(conn, user_changeset)
   end
 
-  def update(conn, %{ "token" => token, "user" => user_params }) do
+  def update(conn, %{ "id" => id, "user" => user_params }) do
+    user = Repo.get!(User, id)
+    user_changeset  = User.changeset(user, user_params)
+
+    case Repo.update(user_changeset) do
+      {:ok, user} ->
+        conn
+        |> put_status(:ok)
+        |> put_resp_header("access-control-allow-origin", "*")
+        |> render("user.json", %{ user: user, token: nil })
+      {:error, changeset} ->
+        handle_error(conn, 400, changeset)
+    end
   end
 
   defp handle_user_signup conn, user_changeset, key \\ nil do

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -31,4 +31,11 @@ defmodule User do
     |> validate_format(:email, ~r/^.+@.+\..+$/)
   end
 
+  def find_by_api_keys(api_id, api_key) do
+    from(u in User,
+         where: u.api_id == ^api_id,
+         where: u.api_key == ^api_key,
+         select: u)
+  end
+
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -11,6 +11,10 @@ defmodule EvercamMedia.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :auth do
+    plug EvercamMedia.AuthenticationPlug
+  end
+
   scope "/", EvercamMedia do
     pipe_through :browser
 
@@ -33,9 +37,14 @@ defmodule EvercamMedia.Router do
     pipe_through :api
 
     post "/users", UserController, :create
-    put "/users", UserController, :update
-    post "/sessions", SessionController, :create
-    delete "/sessions", SessionController, :delete
+
+    scope "/" do
+      pipe_through :auth
+
+      put "/users/:id", UserController, :update
+      post "/sessions", SessionController, :create
+      delete "/sessions", SessionController, :delete
+    end
 
     get "/cameras/:id/ptz/status", ONVIFPTZController, :status
     get "/cameras/:id/ptz/presets", ONVIFPTZController, :presets


### PR DESCRIPTION
Made a little change in the way this is done. In Evercam-API the keys are added in the URL query string. Here I've made the change so they are expected in the HTTP headers. 

The reason behind this is that the change is really tiny, but, it prohibits the users (now, and in the future) to accidentally send a link to Evercam with their API credentials in it.

Thoughts?