### PR TITLE
Add snapshot_id with the new format

### DIFF
--- a/lib/evercam_media/snapshot/db_handler.ex
+++ b/lib/evercam_media/snapshot/db_handler.ex
@@ -142,7 +142,11 @@ defmodule EvercamMedia.Snapshot.DBHandler do
       Calendar.DateTime.Parse.unix!(timestamp)
       |> Calendar.DateTime.to_erl
       |> Ecto.DateTime.cast
-    SnapshotRepo.insert %Snapshot{camera_id: camera.id, data: "S3", notes: "Evercam Proxy", motionlevel: motion_level, created_at: datetime}
+    {:ok, snapshot_timestamp} =
+      Calendar.DateTime.Parse.unix!(timestamp)
+      |> Calendar.Strftime.strftime "%Y%m%d%H%M%S%f"
+    snapshot_id = Util.format_snapshot_id(camera.id, snapshot_timestamp)
+    SnapshotRepo.insert(%Snapshot{camera_id: camera.id, data: "S3", notes: "Evercam Proxy", motionlevel: motion_level, created_at: datetime, snapshot_id = snapshot_id})
   end
 
   defp construct_camera(camera, datetime, _, true) do

--- a/lib/evercam_media/snapshot/db_handler.ex
+++ b/lib/evercam_media/snapshot/db_handler.ex
@@ -146,7 +146,7 @@ defmodule EvercamMedia.Snapshot.DBHandler do
       Calendar.DateTime.Parse.unix!(timestamp)
       |> Calendar.Strftime.strftime "%Y%m%d%H%M%S%f"
     snapshot_id = Util.format_snapshot_id(camera.id, snapshot_timestamp)
-    SnapshotRepo.insert(%Snapshot{camera_id: camera.id, data: "S3", notes: "Evercam Proxy", motionlevel: motion_level, created_at: datetime, snapshot_id = snapshot_id})
+    SnapshotRepo.insert(%Snapshot{camera_id: camera.id, data: "S3", notes: "Evercam Proxy", motionlevel: motion_level, created_at: datetime, snapshot_id: snapshot_id})
   end
 
   defp construct_camera(camera, datetime, _, true) do

--- a/lib/evercam_media/util.ex
+++ b/lib/evercam_media/util.ex
@@ -59,4 +59,16 @@ defmodule EvercamMedia.Util do
       to_char_list(System.get_env["AWS_SECRET_KEY"])
     )
   end
+
+  def format_snapshot_id(camera_id, snapshot_timestamp) do
+    "#{camera_id}_#{format_snapshot_timestamp(snapshot_timestamp)}"
+  end
+
+  def format_snapshot_timestamp(<<snapshot_timestamp::bytes-size(14)>>) do
+    "#{snapshot_timestamp}000"
+  end
+
+  def format_snapshot_timestamp(<<snapshot_timestamp::bytes-size(17)>>) do
+    snapshot_timestamp
+  end
 end

--- a/web/models/snapshot.ex
+++ b/web/models/snapshot.ex
@@ -6,6 +6,7 @@ defmodule Snapshot do
 
     field :data, :string
     field :notes, :string
+    field :snapshot_id, :string
     field :motionlevel, :integer
     field :created_at, Ecto.DateTime, default: Ecto.DateTime.utc
   end


### PR DESCRIPTION
This needs to be deployed after the new `snapshot_id` column is added in `evercam-api`.